### PR TITLE
Fetch and render project from project by id hook

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { toast } from "@/components/ui/use-toast";
 import { ImpactScore, useProjectScoring } from "@/hooks/useProjectScoring";
-import { useProjectsByCategory, useSaveProjectImpact } from "@/hooks/useProjects";
+import { useProjectById, useProjectsByCategory, useSaveProjectImpact } from "@/hooks/useProjects";
 import { setProjectsScored } from "@/utils/localStorage";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -25,6 +25,7 @@ export default function ProjectDetailsPage({ params, searchParams }: { params: {
 	const { category } = searchParams;
 	const router = useRouter();
 	const { data: projects, isPending: isProjectsLoading } = useProjectsByCategory(category);
+	const { data: project, isPending: isProjectLoading } = useProjectById(id);
 	const [isNextProjectLoading, setIsNextProjectLoading] = useState(false);
 	const [isConflictOfInterestDialogOpen, setIsConflictOfInterestDialogOpen] = useState(false);
 	const { projectsScored, isUnlocked, setIsUnlocked, handleScoreSelect } = useProjectScoring(category, id);
@@ -71,7 +72,7 @@ export default function ProjectDetailsPage({ params, searchParams }: { params: {
 		} else {
 			setIsNextProjectLoading(false);
 		}
-	}, [projects, id, category, router, handleScoreSelect, saveProjectImpact, projectsScored]);
+	}, [project, projects, id, category, router, handleScoreSelect, saveProjectImpact, projectsScored]);
 
 	const handleConflictOfInterest = useCallback(() => {
 		setIsConflictOfInterestDialogOpen(true);
@@ -84,7 +85,7 @@ export default function ProjectDetailsPage({ params, searchParams }: { params: {
 		setIsNextProjectLoading(false);
 	}, [handleScore, setIsNextProjectLoading]);
 
-	const currentProject = projects?.find(project => project.projectId === id);
+	const currentProject = project;
 	const isLoading = isProjectsLoading || !currentProject;
 
 	const sidebarProps = useMemo(() => ({
@@ -93,7 +94,7 @@ export default function ProjectDetailsPage({ params, searchParams }: { params: {
 		projectsScored: projectsScored.count,
 		totalProjects: projects?.length ?? 0,
 		isVoted: projectsScored.votedIds.includes(id),
-	}), [handleScore, handleConflictOfInterest, projectsScored, projects, id]);
+	}), [handleScore, handleConflictOfInterest, projectsScored, projects, project, id]);
 
 	if (isLoading) {
 		return <LoadingDialog isOpen={true} setOpen={() => { }} message="Loading project" />;

--- a/src/components/ballot/ballot-states.tsx
+++ b/src/components/ballot/ballot-states.tsx
@@ -32,6 +32,7 @@ export function EmptyBallot() {
       toBeEvaluated: 0,
     }
   }, [ballot])
+  console.log("Ballot (Empty Card):", ballot)
   return (
     <EmptyCard
       icon={BallotSvg} // TO DO: Change to lock

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -2,6 +2,8 @@
 
 import {
 	getProjectsResponse,
+	getRetroFundingRoundProjectById,
+	getRetroFundingRoundProjectByIdResponse,
 	getRetroFundingRoundProjects,
 	getRetroFundingRoundProjectsResponse,
 	updateRetroFundingRoundProjectImpact,
@@ -52,10 +54,13 @@ export function useProjectById(projectId: string) {
 	return useQuery({
 		queryKey: ['projects-by-id', projectId],
 		queryFn: async () =>
-			getRetroFundingRoundProjects(5).then((results: getProjectsResponse) => {
-				const res: ProjectsResponse = results.data;
-				const filtered = res.data?.filter((p) => p.projectId === projectId);
-				return filtered?.[0];
+			// getRetroFundingRoundProjects(5).then((results: getProjectsResponse) => {
+			// 	const res: ProjectsResponse = results.data;
+			// 	const filtered = res.data?.filter((p) => p.projectId === projectId);
+			// 	return filtered?.[0];
+			// }),
+      getRetroFundingRoundProjectById(5, projectId).then((results: getRetroFundingRoundProjectByIdResponse) => {
+				return results.data;
 			}),
 	});
 }


### PR DESCRIPTION
Change the hook used for fetching the project on project details page so its no longer dependent on the category query param. So now the project loads when redirected from ballot for impact scoring.