### PR TITLE
Fix import/export ballot for round 5 allocations

### DIFF
--- a/src/components/ballot/ballot-filter.tsx
+++ b/src/components/ballot/ballot-filter.tsx
@@ -1,59 +1,21 @@
 "use client";
-import {ChevronDown} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {Button} from "@/components/ui/button";
-import {useBallotContext} from "../ballot/provider";
-import {useSortBallot} from "@/hooks/useBallotEditor";
-import {decode, encode, sortLabels} from "@/hooks/useFilter";
-import {exportBallot, ImportBallotDialog} from "./import-ballot";
 import {useState} from "react";
+import { useBallotRound5Context } from "./provider5";
+import { exportRound5Ballot, ImportBallotDialog } from "./import-ballot5";
 
 export function BallotFilter() {
   const [isOpen, setOpen] = useState(false);
-  const { state, ballot } = useBallotContext();
-  const { filter, setFilter } = useSortBallot(state);
+  const { state, ballot } = useBallotRound5Context();
 
   return (
     <div className="flex gap-2">
-      {/* <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Button variant="secondary" iconRight={ChevronDown}>
-            {sortLabels[encode(filter)]}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuLabel>Sort by name</DropdownMenuLabel>
-          <DropdownMenuRadioGroup
-            value={encode(filter)}
-            onValueChange={(value) => setFilter(decode(value))}
-          >
-            {(["name_asc", "name_desc"] as const).map((value) => (
-              <DropdownMenuRadioItem key={value} value={value}>
-                {sortLabels[value]}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-          <DropdownMenuLabel>Sort by weight</DropdownMenuLabel>
-          <DropdownMenuRadioGroup
-            value={encode(filter)}
-            onValueChange={(value) => setFilter(decode(value))}
-          >
-            {(["allocation_asc", "allocation_desc"] as const).map((value) => (
-              <DropdownMenuRadioItem key={value} value={value}>
-                {sortLabels[value]}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu> */}
       <DropdownMenu>
         <DropdownMenuTrigger>
           <Button variant={"secondary"}>...</Button>
@@ -63,7 +25,7 @@ export function BallotFilter() {
             Import ballot
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => exportBallot(ballot?.allocations ?? [])}
+            onClick={() => exportRound5Ballot(ballot?.project_allocations ?? [])}
           >
             Export ballot
           </DropdownMenuItem>
@@ -72,4 +34,5 @@ export function BallotFilter() {
       <ImportBallotDialog isOpen={isOpen} onOpenChange={setOpen} />
     </div>
   );
+
 }

--- a/src/components/ballot/import-ballot5.tsx
+++ b/src/components/ballot/import-ballot5.tsx
@@ -40,7 +40,6 @@ export function ImportBallotDialog({
 function ImportBallotButton() {
   const save = useSaveRound5Allocation();
   const editor = useBallotRound5Context();
-  // const { data: metricIds } = useMetricIds();
 
   const ref = useRef<HTMLInputElement>(null);
 
@@ -50,20 +49,22 @@ function ImportBallotButton() {
       // Parse CSV and build the ballot data (remove name column)
       const { data } = parse<Round5ProjectAllocation>(csvString);
       const allocations = data
-        // .map(({ category_slug, allocation, locked }) => ({
-        //   category_slug,
-        //   allocation: Number(allocation),
-        //   // Only the string "true" and "1" will be matched as locked
-        //   locked: ["true", "1"].includes(String(locked)) ? true : false,
-        // }))
-        // .filter((m) => metricIds?.includes(m.category_slug));
+        .map(({ project_id, allocation }) => ({
+          project_id,
+          name: editor.ballot?.project_allocations.find(p => p.project_id === project_id)?.name,
+          image: editor.ballot?.project_allocations.find(p => p.project_id === project_id)?.image,
+          position: editor.ballot?.project_allocations.find(p => p.project_id === project_id)?.position,
+          allocation: Number(allocation),
+          impact: editor.ballot?.project_allocations.find(p => p.project_id === project_id)?.impact,
+        }) as Round5ProjectAllocation)
 
       if (allocations.length !== data.length) {
         alert(
-          "One or more of the metric IDs were not correct and have been removed."
+          "One or more of the project IDs were not correct and have been removed."
         );
       }
       console.log(allocations);
+
       editor.reset(allocations);
 
       mixpanel.track("Import CSV", { ballotSize: allocations.length });
@@ -101,7 +102,16 @@ function ExportBallotButton() {
   // const emptyBallot: Round5Allocation[] = [
   //   { category_slug: 'ETHEREUM_CORE_CONTRIBUTIONS', allocation: 0, locked: false },
   // ];
-  const emptyBallot: Round5ProjectAllocation[] = [];
+  const {ballot} = useBallotRound5Context()
+  const emptyBallot: any[] = ballot ? 
+    ballot.project_allocations.map(alloc => ({
+      project_id: alloc.project_id,
+      name: alloc.name,
+      allocation: 0,
+    }))
+    : [
+      { project_id: "0x0", name: "Some project", allocation: 0 },
+    ];
 
   return (
     <Button variant="outline" onClick={() => exportRound5Ballot(emptyBallot)}>
@@ -112,12 +122,11 @@ function ExportBallotButton() {
 
 export function exportRound5Ballot(ballot: Round5ProjectAllocation[]) {
   const csv = format(
-    ballot,
-    // ballot.map((alloc) => ({
-    //   category_slug: alloc.category_slug,
-    //   allocation: alloc.allocation,
-    //   locked: alloc.locked,
-    // })),
+    ballot.filter(alloc => alloc.impact !== 0).map((alloc) => ({
+      project_id: alloc.project_id,
+      name: alloc.name,
+      allocation: alloc.allocation,
+    })),
     {}
   );
   console.log(csv);

--- a/src/hooks/useProjectImpact.ts
+++ b/src/hooks/useProjectImpact.ts
@@ -4,7 +4,7 @@ import { request } from "@/lib/request";
 import { useMutation } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 
-export type ImpactScore = 1 | 2 | 3 | 4 | 5;
+export type ImpactScore = 0 | 1 | 2 | 3 | 4 | 5;
 
 export function useSaveProjectImpact() {
   const { toast } = useToast();

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -6,17 +6,21 @@ import {
   getRetroFundingRoundProjects,
   getRetroFundingRoundProjectsResponse,
   updateRetroFundingRoundProjectImpact,
+  updateRetroFundingRoundProjects,
 } from "@/__generated__/api/agora";
 import {
   GetRetroFundingRoundProjectsCategory,
   PageMetadata,
   Project,
+  UpdateRetroFundingRoundProjectsBody,
+  UpdateRetroFundingRoundProjectsBodyProjectsItem,
 } from "@/__generated__/api/agora.schemas";
 import { CategoryType } from "@/data/categories";
 import { CategoryId } from "@/types/shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 import { ImpactScore } from "./useProjectScoring";
+import { toast } from "@/components/ui/use-toast";
 
 export const categoryMap: Record<CategoryType, string> = {
   ETHEREUM_CORE_CONTRIBUTIONS: "eth_core",
@@ -117,6 +121,36 @@ export function useSaveProjectImpact() {
     },
   });
 }
+
+export function useSaveProjects() {
+  const {address} = useAccount()
+  return useMutation({
+    mutationKey: ["save-projects"],
+    mutationFn: async (projects: {
+      project_id: string,
+      allocation: number,
+      impact: ImpactScore
+    }[]) => {
+      return updateRetroFundingRoundProjects(
+        5, 
+        address as string, 
+        {
+          projects: projects.map(p => ({
+            project_id: p.project_id,
+            allocation: p.allocation.toString(),
+            impact: p.impact
+          })) as UpdateRetroFundingRoundProjectsBodyProjectsItem[]
+        }
+      )
+    },
+    onMutate: () => {
+      toast({ title: "Saving projects..." });
+    },
+    onError: () =>
+      toast({ variant: "destructive", title: "Error saving projects" }),
+  });
+}
+
 
 export function useProjectById(projectId: string) {
   return useQuery({


### PR DESCRIPTION
Updated the ballot import and export option to round 5. There is still a minor bug when it comes to saving project allocations after importing the ballot. No error message occurs yet the project allocations do not save after calling the POST `/projects` endpoint in the API.