### PR TITLE
Fix null budget and category allocations

### DIFF
--- a/src/app/ballot/page.tsx
+++ b/src/app/ballot/page.tsx
@@ -538,13 +538,16 @@ function YourBallot() {
 function BallotSubmitButton({ onClick }: ComponentProps<typeof Button>) {
   const allocationSum = useRound5BallotWeightSum();
   const [seconds] = useVotingTimeLeft(votingEndDate);
+  const { getBudget: { data: budgetData } } = useBudget(5);
+
+  const isBudgetIncomplete = !budgetData?.budget || !budgetData.allocations || budgetData.allocations.length == 0
 
   if (Number(seconds) < 0) {
     return null;
   }
   return (
     <Button
-      disabled={allocationSum !== 100}
+      disabled={allocationSum !== 100 || isBudgetIncomplete}
       variant={'destructive'}
       type="submit"
       onClick={onClick}
@@ -561,6 +564,7 @@ function WeightsError() {
   }, [allocationSum]);
 
   const { data: distributionMethod } = useDistributionMethodFromLocalStorage();
+  const { getBudget: { data: budgetData } } = useBudget(5);
 
   if (!distributionMethod)
     return (
@@ -568,6 +572,14 @@ function WeightsError() {
         Choose an allocation method at the top of this ballot.
       </span>
     );
+
+  const isBudgetIncomplete = !budgetData?.budget || !budgetData.allocations || budgetData.allocations.length == 0
+
+  if (Math.abs(remainingAllocation) < 0.01 && isBudgetIncomplete) {
+    return <span className="text-sm text-destructive">
+      Please set <a href={`/budget`} className="underline">your budget and category allocations</a> before submitting.
+    </span>
+  }
 
   // Treat the allocation as complete if the remaining allocation is negligible
   if (Math.abs(remainingAllocation) < 0.01) return null;

--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -10,6 +10,7 @@ import { Separator } from '@/components/ui/separator';
 import { DisconnectedState } from '@/components/common/disconnected-state';
 import { useAccount } from 'wagmi';
 import { Loader2 } from 'lucide-react';
+import { PostSubmissionBanner } from '@/components/ballot/post-submission-banner';
 
 export default function BudgetBallotPage() {
   const { isConnecting, isConnected } = useAccount();
@@ -43,6 +44,7 @@ export default function BudgetBallotPage() {
     <BudgetProvider>
       <div className="flex flex-row gap-12">
         <section className="flex-grow max-w-[720px] space-y-6">
+          <PostSubmissionBanner />
           <BallotTabs />
           <p className="text-gray-600">
             Decide on the budget for this round, and then decide how much should

--- a/src/hooks/useBudgetForm.ts
+++ b/src/hooks/useBudgetForm.ts
@@ -73,7 +73,7 @@ export function useBudgetForm() {
   useEffect(() => {
     if (getBudget.data) {
       const newAllocations: Record<string, number> = {};
-      setTotalBudget(getBudget.data.budget ?? 2000000);
+      setTotalBudget(getBudget.data.budget ?? 8000000);
 
       getBudget.data.allocations?.forEach((allocation) => {
         if (allocation.category_slug !== undefined) {

--- a/src/hooks/useBudgetForm.ts
+++ b/src/hooks/useBudgetForm.ts
@@ -14,7 +14,7 @@ export function useBudgetForm() {
   const { address } = useAccount();
   const allProjectsByCategory = useAllProjectsByCategory();
   const { getBudget, saveAllocation } = useBudget(roundId);
-  const [totalBudget, setTotalBudget] = useState<number>(2000000);
+  const [totalBudget, setTotalBudget] = useState<number>(8000000);
   const [allocations, setAllocations] = useState<Record<string, number>>({});
   const [lockedFields, setLockedFields] = useState<Record<string, boolean>>({});
   const [error, setError] = useState('');


### PR DESCRIPTION
I added a couple precautions to avoid the null budget and category allocations.
1. Once `/budget` page is loaded, I automatically save the budget and category allocations to the default values (only happens if these values aren't already set)
2. For safe measure, I included a warning text and disabled the submit button on the ballot page if they still return with no values for some reason. The warning text links them back to the budget page.