### PR TITLE
More touch ups on post-submission banner and toasts

### DIFF
--- a/src/components/ballot/import-ballot5.tsx
+++ b/src/components/ballot/import-ballot5.tsx
@@ -2,7 +2,9 @@
 
 import { useSession } from '@/hooks/useAuth';
 import {
+  DistributionMethod,
   Round5ProjectAllocation,
+  useDistributionMethodFromLocalStorage,
   useRound5Ballot,
 } from '@/hooks/useBallotRound5';
 import { ImpactScore } from '@/hooks/useProjectImpact';
@@ -55,6 +57,7 @@ function ImportBallotButton({ onClose }: { onClose: () => void }) {
   const { data: projects } = useProjectsByCategory(
     session?.category as CategoryId
   );
+  const { update } = useDistributionMethodFromLocalStorage()
 
   const ref = useRef<HTMLInputElement>(null);
 
@@ -93,18 +96,16 @@ function ImportBallotButton({ onClose }: { onClose: () => void }) {
 
       mixpanel.track('Import CSV', { ballotSize: allocations.length });
 
-      saveProjects(
-        allocations.filter(
+      saveProjects({
+        projects: allocations.filter(
           (alloc) =>
             !!projects?.find((p) => p.applicationId === alloc.project_id)
-        )
-      )
+        ),
+        action: 'import',
+      })
         .then(() => {
+          update(DistributionMethod.CUSTOM);
           refetch();
-          toast({
-            title: 'Ballot imported successfully',
-            variant: 'default',
-          });
           onClose();
         })
         .catch((e) => {

--- a/src/components/ballot/post-submission-banner.tsx
+++ b/src/components/ballot/post-submission-banner.tsx
@@ -8,6 +8,7 @@ import { Button } from '../ui/button';
 import { ArrowDownToLineIcon } from 'lucide-react';
 import { votingEndDate } from '@/config';
 import { downloadImage } from './submit-dialog5';
+import { useBallotRound5Context } from './provider5';
 
 const monthNames = [
   'Jan',
@@ -29,15 +30,17 @@ const getMonthName = (monthNumber: number) => {
 };
 
 export function PostSubmissionBanner() {
-  const { data } = useBallotSubmission();
-  if (!data) return null;
+  // const { data } = useBallotSubmission();
+  const { ballot } = useBallotRound5Context();
+
+  if (!ballot || ballot.status !== 'SUBMITTED' || !ballot.submitted_at) return null;
 
   const dueDate = `${getMonthName(votingEndDate.getMonth() + 1)} ${votingEndDate.getDate()}`;
-  const submittedDate = new Date(data.timestamp).toLocaleDateString('en-US', {
+  const submittedDate = new Date(ballot.submitted_at).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
   });
-  const submittedTime = new Date(data.timestamp).toLocaleTimeString('en-US', {
+  const submittedTime = new Date(ballot.submitted_at).toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
   });

--- a/src/components/metrics-editor/index.tsx
+++ b/src/components/metrics-editor/index.tsx
@@ -68,7 +68,7 @@ export function MetricsEditor({ budget }: { budget: number }) {
     {
       name: 'Custom',
       description: 'Reward allocation is customized by you.',
-      method: 'CUSTOM',
+      method: DistributionMethod.CUSTOM,
       image: Custom,
     },
   ];

--- a/src/components/metrics-editor/reset-button.tsx
+++ b/src/components/metrics-editor/reset-button.tsx
@@ -29,13 +29,14 @@ export function ResetButton() {
 
   const handleReset = async () => {
     if (!ballot?.project_allocations || !address) return;
-    await saveProjects(
-      ballot.project_allocations.map((project) => ({
+    await saveProjects({
+      projects: ballot.project_allocations.map((project) => ({
         project_id: project.project_id,
         allocation: '0',
         impact: project.impact as ImpactScore,
-      }))
-    );
+      })),
+      action: 'reset',
+    });
 
     resetDistributionMethod();
 

--- a/src/hooks/useBallotRound5.ts
+++ b/src/hooks/useBallotRound5.ts
@@ -50,6 +50,7 @@ export type Round5Ballot = {
   created_at?: string;
   updated_at?: string;
   published_at?: string;
+  submitted_at?: string;
   category_allocations: Round5CategoryAllocation[];
   project_allocations: Round5ProjectAllocation[];
   projects_to_be_evaluated: string[];

--- a/src/hooks/useBallotRound5.ts
+++ b/src/hooks/useBallotRound5.ts
@@ -327,7 +327,8 @@ export function useDistributionMethod() {
     },
     onMutate: () =>
       toast({
-        title: 'Loading...',
+        title: 'Loading',
+        loading: true,
       }),
     onError: () =>
       toast({

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -125,6 +125,7 @@ export function useSaveProjectImpact() {
   });
 }
 
+export type SaveProjectsActionType = 'reset' | 'import';
 export function useSaveProjects() {
   const { address } = useAccount();
   const queryClient = useQueryClient();
@@ -132,11 +133,14 @@ export function useSaveProjects() {
   return useMutation({
     mutationKey: ['save-projects'],
     mutationFn: async (
-      projects: {
-        project_id: string;
-        allocation: string;
-        impact: 0 | 1 | 2 | 3 | 4 | 5;
-      }[]
+      { projects }: {
+        projects: {
+          project_id: string;
+          allocation: string;
+          impact: 0 | 1 | 2 | 3 | 4 | 5;
+        }[];
+        action?: SaveProjectsActionType;
+      }
     ) => {
       await request
         .post(`${agoraRoundsAPI}/ballots/${address}/projects`, {
@@ -149,10 +153,17 @@ export function useSaveProjects() {
         });
     },
     onMutate: () => {
-      toast({ title: 'Saving projects...' });
+      toast({ title: 'Loading', loading: true });
     },
-    onError: () =>
-      toast({ variant: 'destructive', title: 'Error saving projects' }),
+    onError: (_, { action }) => {
+      if (action === 'reset') {
+        toast({ variant: 'destructive', title: 'Error resetting ballot' });
+      } else if (action === 'import') {
+        toast({ variant: 'destructive', title: 'Error importing ballot' });
+      } else {
+        toast({ variant: 'destructive', title: 'Error saving ballot' });
+      }
+    },
   });
 }
 


### PR DESCRIPTION
Cleaned up the loading toasts for ballot imports, resets and allocation method selection. Now all consistently use the spinner animation and "Loading" text without the "..." at the end. Error toast cleaned up too. Lastly, the post-submission banner now reads directly from the API instead of the cached submission data in local storage.