### PR TITLE
Check the return status and revert if not 200

### DIFF
--- a/src/hooks/useBallotRound5.ts
+++ b/src/hooks/useBallotRound5.ts
@@ -146,6 +146,11 @@ export function useSubmitBallot({ onSuccess }: { onSuccess: () => void }) {
           ballot_content,
           signature,
         });
+        if (submission.status != 200) {
+          throw new Error('Failed submitting ballot', {
+            cause: submission.status,
+          });
+        }
       } catch (error) {
         console.error(error);
         throw new Error('Error submitting ballot');


### PR DESCRIPTION
This time it should actually resolve issue #284. The reason the error toast was not showing at times is because the API for `/submit` still returns an object. In that object, there is a status property that was not checked. Now, if the status is not `200` in that return object, the hook function reverts. Then the toast pops up in the UI.