### PR TITLE
Fix support for smart contract wallet sign-in

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -46,7 +46,7 @@ const { wallets } = getDefaultWallets();
 const config = getDefaultConfig({
   appName: 'OP Round 5',
   projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_ID!,
-  chains: [mainnet, optimism],
+  chains: [optimism, mainnet],
   wallets: [
     ...wallets,
     {


### PR DESCRIPTION
Currently Coinbase Smart Wallet (or any other smart contract wallets) cannot be used to sign in on the Round 5 site. This is because EIP-1271 signature validation is broken because the agora backend uses chainId 10 (https://github.com/voteagora/agora-next/blob/main/src/lib/serverVerifyMessage.ts#L28-L32) but the signature request is using chainId 1.

This PR fixes that by ensuring the signed message request sent to the wallet is using chainId 10, by setting the first chain (and therefore the default) passed to rainbowkit is optimism.

An alternative might be to remove mainnet altogether (not sure if the L1 is used anywhere?).

Tested and confirmed working locally (by live editing the javascript on the production site).