### PR TITLE
Remove mainnet from chain config

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -46,7 +46,7 @@ const { wallets } = getDefaultWallets();
 const config = getDefaultConfig({
   appName: 'OP Round 5',
   projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_ID!,
-  chains: [optimism, mainnet],
+  chains: [optimism],
   wallets: [
     ...wallets,
     {


### PR DESCRIPTION
This is to resolve issue #316. Now forcing users to be on OP mainnet for signature verification.